### PR TITLE
feat: rescore-only mode + CSV export for applicant reviews

### DIFF
--- a/src/app/api/applicant-reviews/batch-eval-runs/route.ts
+++ b/src/app/api/applicant-reviews/batch-eval-runs/route.ts
@@ -19,8 +19,8 @@ export async function POST(request: NextRequest) {
     batch_id: body.batch_id ?? null,
   };
   if (body.rescore_only) {
-    proxyBody.rescore_only = true;
-    proxyBody.review_bonfire_id = body.review_bonfire_id;
+    proxyBody["rescore_only"] = true;
+    proxyBody["review_bonfire_id"] = body.review_bonfire_id;
   }
 
   return handleProxyRequest("/applicant-reviews/batch-eval-runs", {

--- a/src/app/api/applicant-reviews/batch-eval-runs/route.ts
+++ b/src/app/api/applicant-reviews/batch-eval-runs/route.ts
@@ -6,21 +6,30 @@ import {
   handleProxyRequest,
 } from "@/lib/api/server-utils";
 
+interface BatchEvalRunBody {
+  application_ids: string[];
+  rubric_id?: string | null;
+  force?: boolean;
+  batch_id?: string | null;
+  rescore_only?: boolean;
+  review_bonfire_id?: string | null;
+}
+
 export async function POST(request: NextRequest) {
   const body = await request.json();
   if (!body?.application_ids || !Array.isArray(body.application_ids)) {
     return createErrorResponse("application_ids array is required", 400);
   }
 
-  const proxyBody: Record<string, unknown> = {
+  const proxyBody: BatchEvalRunBody = {
     application_ids: body.application_ids,
     rubric_id: body.rubric_id ?? null,
     force: body.force ?? false,
     batch_id: body.batch_id ?? null,
   };
   if (body.rescore_only) {
-    proxyBody["rescore_only"] = true;
-    proxyBody["review_bonfire_id"] = body.review_bonfire_id;
+    proxyBody.rescore_only = true;
+    proxyBody.review_bonfire_id = body.review_bonfire_id;
   }
 
   return handleProxyRequest("/applicant-reviews/batch-eval-runs", {

--- a/src/app/api/applicant-reviews/batch-eval-runs/route.ts
+++ b/src/app/api/applicant-reviews/batch-eval-runs/route.ts
@@ -12,14 +12,20 @@ export async function POST(request: NextRequest) {
     return createErrorResponse("application_ids array is required", 400);
   }
 
+  const proxyBody: Record<string, unknown> = {
+    application_ids: body.application_ids,
+    rubric_id: body.rubric_id ?? null,
+    force: body.force ?? false,
+    batch_id: body.batch_id ?? null,
+  };
+  if (body.rescore_only) {
+    proxyBody.rescore_only = true;
+    proxyBody.review_bonfire_id = body.review_bonfire_id;
+  }
+
   return handleProxyRequest("/applicant-reviews/batch-eval-runs", {
     method: "POST",
-    body: {
-      application_ids: body.application_ids,
-      rubric_id: body.rubric_id ?? null,
-      force: body.force ?? false,
-      batch_id: body.batch_id ?? null,
-    },
+    body: proxyBody,
   });
 }
 

--- a/src/app/api/applicant-reviews/export-csv/route.ts
+++ b/src/app/api/applicant-reviews/export-csv/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { auth } from "@clerk/nextjs/server";
+
+const getBackendUrl = (): string =>
+  process.env["DELVE_API_URL"] ??
+  process.env["NEXT_PUBLIC_DELVE_API_URL"] ??
+  "http://localhost:8000";
+
+export async function GET(request: NextRequest) {
+  const { getToken } = await auth();
+  const token = await getToken();
+
+  const { searchParams } = request.nextUrl;
+  const bonfireId = searchParams.get("bonfire_id");
+  if (!bonfireId) {
+    return NextResponse.json({ error: "bonfire_id is required" }, { status: 400 });
+  }
+
+  const params = new URLSearchParams({ bonfire_id: bonfireId });
+  const batchId = searchParams.get("batch_id");
+  const rubricId = searchParams.get("rubric_id");
+  if (batchId) params.set("batch_id", batchId);
+  if (rubricId) params.set("rubric_id", rubricId);
+
+  const url = `${getBackendUrl()}/applicant-reviews-export?${params.toString()}`;
+  const response = await fetch(url, {
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    return NextResponse.json(
+      { error: `Backend returned ${response.status}` },
+      { status: response.status },
+    );
+  }
+
+  const csvData = await response.text();
+  return new NextResponse(csvData, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv",
+      "Content-Disposition": "attachment; filename=applicant_reviews.csv",
+    },
+  });
+}

--- a/src/components/dashboard/ApplicantReviewsSection.tsx
+++ b/src/components/dashboard/ApplicantReviewsSection.tsx
@@ -172,7 +172,7 @@ export function ApplicantReviewsSection({
     ]);
   };
 
-  const handleReevaluateAll = () => {
+  const handleReevaluateAll = (rescoreOnly = false) => {
     batchProgress.open(batchId ?? "");
     void (async () => {
       try {
@@ -183,20 +183,46 @@ export function ApplicantReviewsSection({
           toast.success("All applications already evaluated.");
           return;
         }
+        const reviewBonfireId = rescoreOnly ? batchProgress.batch?.review_bonfire_id : undefined;
+        if (rescoreOnly && !reviewBonfireId) {
+          toast.error("No previous review bonfire found — run a full evaluation first.");
+          return;
+        }
         await applicationActions.reevaluateAll(
           toEvaluate.map((a) => a.id),
           batchId ?? undefined,
           selectedRubricId,
           true,
+          rescoreOnly,
+          reviewBonfireId ?? undefined,
         );
         await queryClient.invalidateQueries({ queryKey: ["applicantReviewBatch"] });
         await refreshData();
         applicationActions.clearProgress();
-        toast.success("Re-evaluation complete.");
+        toast.success(rescoreOnly ? "Re-scoring complete." : "Re-evaluation complete.");
       } catch (err) {
         toast.error(err instanceof Error ? err.message : "Re-evaluation failed.");
       }
     })();
+  };
+
+  const handleExportCsv = async () => {
+    try {
+      const params = new URLSearchParams({ bonfire_id: bonfireId });
+      if (batchId) params.set("batch_id", batchId);
+      if (selectedRubricId) params.set("rubric_id", selectedRubricId);
+      const response = await fetch(`/api/applicant-reviews/export-csv?${params.toString()}`);
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `applicant_reviews_${batchId ?? bonfireId}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "CSV export failed.");
+    }
   };
 
   return (
@@ -302,10 +328,29 @@ export function ApplicantReviewsSection({
               <button
                 className="bf-btn-primary"
                 style={{ fontSize: 12, padding: "6px 14px" }}
-                onClick={handleReevaluateAll}
+                onClick={() => handleReevaluateAll(false)}
                 disabled={applicationActions.isReevaluating}
               >
-                {applicationActions.isReevaluating ? "Evaluating..." : "Rescore All"}
+                {applicationActions.isReevaluating ? "Evaluating..." : "Evaluate All"}
+              </button>
+              {batchProgress.batch?.review_bonfire_id && (
+                <button
+                  className="bf-btn-primary"
+                  style={{ fontSize: 12, padding: "6px 14px", opacity: 0.9 }}
+                  onClick={() => handleReevaluateAll(true)}
+                  disabled={applicationActions.isReevaluating}
+                  title="Re-run scoring only — skip research and KG ingestion"
+                >
+                  Rescore Only
+                </button>
+              )}
+              <button
+                className="bf-btn-primary"
+                style={{ fontSize: 12, padding: "6px 14px", opacity: 0.8 }}
+                onClick={() => void handleExportCsv()}
+                title="Download batch results as CSV"
+              >
+                Export CSV
               </button>
               {batchId && (
                 <button

--- a/src/hooks/queries/useApplicationActions.ts
+++ b/src/hooks/queries/useApplicationActions.ts
@@ -27,11 +27,11 @@ export function useApplicationActions() {
   }, []);
 
   const reevaluateAll = useCallback(
-    async (applicationIds: string[], batchId?: string, rubricId?: string | null, force?: boolean) => {
+    async (applicationIds: string[], batchId?: string, rubricId?: string | null, force?: boolean, rescoreOnly?: boolean, reviewBonfireId?: string) => {
       if (applicationIds.length === 0) return;
       setReevaluateProgress({ completed: 0, total: applicationIds.length });
       try {
-        await startStream(applicationIds, batchId, rubricId, force);
+        await startStream(applicationIds, batchId, rubricId, force, rescoreOnly, reviewBonfireId);
       } finally {
         if (streamState.status === "complete") {
           setReevaluateProgress({

--- a/src/hooks/queries/useBatchEvaluateStream.ts
+++ b/src/hooks/queries/useBatchEvaluateStream.ts
@@ -330,7 +330,7 @@ export function useBatchEvaluateStream() {
   const runIdRef = useRef<string | null>(null);
 
   const startStream = useCallback(
-    async (applicationIds: string[], batchId?: string, rubricId?: string | null, force?: boolean) => {
+    async (applicationIds: string[], batchId?: string, rubricId?: string | null, force?: boolean, rescoreOnly?: boolean, reviewBonfireId?: string) => {
       // Cancel any existing stream
       abortRef.current?.abort();
 
@@ -352,6 +352,10 @@ export function useBatchEvaluateStream() {
         if (rubricId) createBody["rubric_id"] = rubricId;
         if (force) createBody["force"] = true;
         if (batchId) createBody["batch_id"] = batchId;
+        if (rescoreOnly && reviewBonfireId) {
+          createBody["rescore_only"] = true;
+          createBody["review_bonfire_id"] = reviewBonfireId;
+        }
 
         const createResponse = await fetch(
           "/api/applicant-reviews/batch-eval-runs",


### PR DESCRIPTION
- Wire rescore_only + review_bonfire_id through batch-eval-runs proxy
- Add "Rescore Only" button (visible when prior review bonfire exists)
- Add "Export CSV" button with /export-csv proxy route
- Rename "Rescore All" to "Evaluate All" for clarity